### PR TITLE
Feature: Added getPlayersByName

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { getMatchById } from './match'
 import { getMatches } from './matches'
 import { getResults } from './results'
 import { getTopPlayers } from './players'
-import { getPlayerById } from './player'
+import { getPlayerById, getPlayersByName } from './player'
 import { getTopTeams } from './teams'
 import { getTeamById } from './team'
 import getRSS from './rss'
@@ -14,6 +14,7 @@ export default {
   getMatches,
   getTopPlayers,
   getPlayerById,
+  getPlayersByName,
   getTopTeams,
   getTeamById,
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -438,4 +438,22 @@ describe('hltv-api', () => {
     )
     await expect(HLTV.getTeamById(0)).rejects.toEqual(err)
   })
+
+  it('should return player Ids from a name substring when we call `getPlayersByName`', async () => {
+    expect.hasAssertions()
+    const response = await HLTV.getPlayersByName('ZyW')
+    const resultA = response[0]
+    const resultB = response[1] // return an array
+
+    expect(resultA.nickname).toBe('zywoo') // Because nicknames are pulled from an href, all strings are lowercase
+    expect(resultA.id).toBe(11893)
+    expect(resultB.nickname).toBe('dizzywi')
+    expect(resultB.id).toBe(13178)
+  })
+
+  it('should throw `getPlayersByName`', async () => {
+    expect.hasAssertions()
+    const err = new Error('Error: Could not find players beginning with that string')
+    await expect(HLTV.getPlayersByName('AAAAAAAAAAAAAAAAAAAAAAAAAAAA')).rejects.toEqual(err)
+  })
 })


### PR DESCRIPTION
`HLTV.getPlayersByName("substr")` Returns an array of dicts: `[{id: ..., nickname: ...}, {...}, {...}]` from the results of HLTV.org/search. Includes tests.
(Note that search operates only on nicknames. Though HLTV's results page shows first names and last names, these cannot be searched for).