### PR TITLE
Add API to get matches by EventId

### DIFF
--- a/examples/endpoints.js
+++ b/examples/endpoints.js
@@ -14,6 +14,12 @@ function makeEndpoints(app, HLTV) {
     res.json(matches)
   })
 
+  app.get('/matches/:eventId', async (req, res) => {
+    const { eventId } = req.params
+    const matches = await HLTV.getMatches(eventId)
+    res.json(matches)
+  })
+
   app.get('/results/:matchId/stats', async (req, res) => {
     const { matchId } = req.params
     const match = await HLTV.getMatchById(matchId)

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -21,8 +21,10 @@ interface IMatch {
   teams: ITeam[]
 }
 
-export async function getMatches() {
-  const url = `${CONFIG.BASE}/${CONFIG.MATCHES}`
+export async function getMatches(eventId?: number) {
+  const url = eventId
+    ? `${CONFIG.BASE}/events/${eventId}/${CONFIG.MATCHES}`
+    : `${CONFIG.BASE}/${CONFIG.MATCHES}`
 
   try {
     const body = await (

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -22,9 +22,10 @@ interface IMatch {
 }
 
 export async function getMatches(eventId?: number) {
-  const url = eventId
-    ? `${CONFIG.BASE}/events/${eventId}/${CONFIG.MATCHES}`
-    : `${CONFIG.BASE}/${CONFIG.MATCHES}`
+  const url =
+    eventId !== undefined
+      ? `${CONFIG.BASE}/events/${eventId}/${CONFIG.MATCHES}`
+      : `${CONFIG.BASE}/${CONFIG.MATCHES}`
 
   try {
     const body = await (

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -323,6 +323,32 @@ describe('hltv-api', () => {
     }
   })
 
+  it('should have stats of all matches when we call `getMatches` passing eventId', async () => {
+    expect.hasAssertions()
+    const response = await HLTV.getMatches(6588)
+    expect(response.length).toBeGreaterThan(0)
+    const result = response[0]
+    expect(result.id).toBeDefined()
+    expect(result.event.name).toBeDefined()
+    expect(result.event.logo).toContain(CONFIG.CDN)
+    expect(result.stars).toBeDefined()
+    expect(result.teams[0].name).toBeDefined()
+    expect(result.teams[1].name).toBeDefined()
+    if (result.teams[0].logo && !result.teams[0].logo.includes('placeholder.svg')) {
+      expect(result.teams[0].logo).toContain(CONFIG.CDN)
+    }
+    if (result.teams[1].logo && !result.teams[1].logo.includes('placeholder.svg')) {
+      expect(result.teams[1].logo).toContain(CONFIG.CDN)
+    }
+  })
+
+  it('should throw when `getMatches` is invoked with an eventId that does not exists', async () => {
+    const err = new Error(
+      'Error: There are no matches available, something went wrong. Please contact the library maintainer on https://github.com/dajk/hltv-api'
+    )
+    await expect(HLTV.getMatches(0)).rejects.toEqual(err)
+  })
+
   it('should have info of all players when we call `getTopPlayers`', async () => {
     expect.hasAssertions()
     const response = await HLTV.getTopPlayers()

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -33,6 +33,11 @@ export default function Home() {
             </Link>
           </li>
           <li>
+            <Link href="/api/matchesByEvent.json">
+              <a>Matches (by event id)</a>
+            </Link>
+          </li>
+          <li>
             <Link href="/api/match.json">
               <a>Stats (by match id)</a>
             </Link>

--- a/website/write.js
+++ b/website/write.js
@@ -5,20 +5,24 @@ const requests = [
   HLTV.getNews(),
   HLTV.getResults(),
   HLTV.getMatches(),
+  HLTV.getMatches(6588),
   HLTV.getMatchById(2352470),
   HLTV.getTopPlayers(),
   HLTV.getPlayerById(11893),
   HLTV.getTopTeams(),
   HLTV.getTeamById(4608),
 ]
-Promise.all(requests).then(([news, results, matches, match, players, player, teams, team]) => {
-  const base = `public/api`
-  fs.writeFileSync(`${base}/news.json`, `${JSON.stringify(news, null, 2)}\n`)
-  fs.writeFileSync(`${base}/results.json`, `${JSON.stringify(results, null, 2)}\n`)
-  fs.writeFileSync(`${base}/matches.json`, `${JSON.stringify(matches, null, 2)}\n`)
-  fs.writeFileSync(`${base}/match.json`, `${JSON.stringify(match, null, 2)}\n`)
-  fs.writeFileSync(`${base}/players.json`, `${JSON.stringify(players, null, 2)}\n`)
-  fs.writeFileSync(`${base}/player.json`, `${JSON.stringify(player, null, 2)}\n`)
-  fs.writeFileSync(`${base}/teams.json`, `${JSON.stringify(teams, null, 2)}\n`)
-  fs.writeFileSync(`${base}/team.json`, `${JSON.stringify(team, null, 2)}\n`)
-})
+Promise.all(requests).then(
+  ([news, results, matches, matchesByEvent, , match, players, player, teams, team]) => {
+    const base = `public/api`
+    fs.writeFileSync(`${base}/news.json`, `${JSON.stringify(news, null, 2)}\n`)
+    fs.writeFileSync(`${base}/results.json`, `${JSON.stringify(results, null, 2)}\n`)
+    fs.writeFileSync(`${base}/matches.json`, `${JSON.stringify(matches, null, 2)}\n`)
+    fs.writeFileSync(`${base}/matchesByEvent.json`, `${JSON.stringify(matchesByEvent, null, 2)}\n`)
+    fs.writeFileSync(`${base}/match.json`, `${JSON.stringify(match, null, 2)}\n`)
+    fs.writeFileSync(`${base}/players.json`, `${JSON.stringify(players, null, 2)}\n`)
+    fs.writeFileSync(`${base}/player.json`, `${JSON.stringify(player, null, 2)}\n`)
+    fs.writeFileSync(`${base}/teams.json`, `${JSON.stringify(teams, null, 2)}\n`)
+    fs.writeFileSync(`${base}/team.json`, `${JSON.stringify(team, null, 2)}\n`)
+  }
+)


### PR DESCRIPTION
This PR adds a parameter `eventId` on `getMatches` method to filter matches for a specific event.